### PR TITLE
take care of .tgz as well

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -91,7 +91,7 @@ module.exports = {
             rq.pipe(stream);
         }
 
-        if (extention === '.gz') {
+        if (extention === '.gz' || extension === '.tgz' ) {
             rq.on('response', function(res) {
                 if (res.statusCode !== 200) return;
                 self.extractTar(res, cachepath).then(self.stripRootFolder).then(function() {


### PR DESCRIPTION
Github would enforce the suffix ".tgz" to the release binary in some case. This change would make ".tgz" be supported.